### PR TITLE
build: Reactivity Transform

### DIFF
--- a/src/accounts/pages/sign-in.component.vue
+++ b/src/accounts/pages/sign-in.component.vue
@@ -1,17 +1,17 @@
 <script setup>
 import InputText from "primevue/inputtext";
-import { ref } from "vue";
+import { $ref } from "vue/macros";
 import { useRouter, RouterLink } from "vue-router";
 import { AuthenticationService } from "../services/authentication.service";
 
-const email = ref("");
-const password = ref("");
+const email = $ref("");
+const password = $ref("");
 
 const router = useRouter();
-const auth = ref(AuthenticationService.instance);
+const auth = $ref(AuthenticationService.instance);
 
 const handleLogin = () => {
-  auth.value.login();
+  auth.login();
   router.push("/");
 };
 </script>

--- a/src/accounts/pages/sign-up.component.vue
+++ b/src/accounts/pages/sign-up.component.vue
@@ -3,22 +3,22 @@ import InputMask from "primevue/inputmask";
 import InputText from "primevue/inputtext";
 import ToggleButton from "primevue/togglebutton";
 import { PrimeIcons } from "primevue/api";
-import { ref } from "vue";
+import { $ref } from "vue/macros";
 import { AuthenticationService } from "../services/authentication.service";
 import { useRouter, RouterLink } from "vue-router";
 
-const checked = ref(false);
-const fullname = ref("");
-const username = ref("");
-const email = ref("");
-const password = ref("");
-const phone = ref("");
+const checked = $ref(false);
+const fullname = $ref("");
+const username = $ref("");
+const email = $ref("");
+const password = $ref("");
+const phone = $ref("");
 
-const auth = ref(AuthenticationService.instance);
+const auth = $ref(AuthenticationService.instance);
 const router = useRouter();
 
 const handleRegister = () => {
-  auth.value.login();
+  auth.login();
   router.push("/");
 };
 </script>

--- a/src/core/components/base-footer.vue
+++ b/src/core/components/base-footer.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Dropdown from "primevue/dropdown";
-import { ref } from "vue";
+import { $ref } from "vue/macros";
 
 const navigation = [
   {
@@ -30,7 +30,7 @@ const languages = [
   { label: "English", code: "en_US" },
   { label: "Spanish", code: "es_PE" },
 ];
-const selectedLang = ref(languages[0]);
+const selectedLang = $ref(languages[0]);
 </script>
 
 <template>

--- a/src/core/components/base-header.vue
+++ b/src/core/components/base-header.vue
@@ -3,7 +3,8 @@ import Menu from "primevue/menu";
 import Avatar from "primevue/avatar";
 import { PrimeIcons } from "primevue/api";
 import { useMq } from "vue3-mq";
-import { onMounted, ref, watchEffect } from "vue";
+import { onMounted, watchEffect } from "vue";
+import { $ref } from "vue/macros";
 import { RouterLink, useRouter } from "vue-router";
 import { AuthenticationService } from "@/accounts/services/authentication.service";
 
@@ -11,11 +12,11 @@ const mq = useMq();
 
 const router = useRouter();
 
-const auth = ref(AuthenticationService.instance);
-const user = ref(auth.value.getCurrentUser());
+const auth = $ref(AuthenticationService.instance);
+let user = $ref(auth.getCurrentUser());
 
 watchEffect(() => {
-  user.value = auth.value.getCurrentUser();
+  user = auth.getCurrentUser();
 });
 
 const navigation = [
@@ -25,47 +26,47 @@ const navigation = [
   { label: "Notices", path: "/notifications", icon: PrimeIcons.BELL },
 ];
 
-const search = ref("");
+const search = $ref("");
 
-/** @type {import("vue").Ref<import("primevue/menu").default>} */
-const menuRef = ref();
+/** @type {import("primevue/menu").default} */
+const menuRef = $ref();
 /** @param {MouseEvent} event */
 const toggleMenu = event => {
-  menuRef.value.toggle(event);
+  menuRef.toggle(event);
 };
 
 /** @type {import("vue").Ref<import("primevue/menuitem").MenuItem[]>} */
-const accountMenu = ref([]);
+let accountMenu = $ref([]);
 const updateMenu = () => {
-  accountMenu.value = [
+  accountMenu = [
     {
       label: "Sign In",
       to: "/account/signin",
       icon: PrimeIcons.SIGN_IN,
-      visible: !auth.value.loggedIn,
+      visible: !auth.loggedIn,
     },
     {
       label: "Sign Up",
       to: "/account/signup",
       icon: PrimeIcons.USER_PLUS,
-      visible: !auth.value.loggedIn,
+      visible: !auth.loggedIn,
     },
     ...navigation.map(item => ({
       label: item.label,
       icon: item.icon,
-      visible: mq.mdMinus && auth.value.loggedIn,
+      visible: mq.mdMinus && auth.loggedIn,
     })),
-    { separator: true, visible: mq.mdMinus && auth.value.loggedIn },
-    { label: "Profile", icon: PrimeIcons.USER, visible: auth.value.loggedIn },
-    { label: "Options", icon: PrimeIcons.COG, visible: auth.value.loggedIn },
+    { separator: true, visible: mq.mdMinus && auth.loggedIn },
+    { label: "Profile", icon: PrimeIcons.USER, visible: auth.loggedIn },
+    { label: "Options", icon: PrimeIcons.COG, visible: auth.loggedIn },
     {
       label: "Sign Out",
       command: () => {
-        auth.value.logout();
+        auth.logout();
         router.push("/account/signin");
       },
       icon: PrimeIcons.POWER_OFF,
-      visible: auth.value.loggedIn,
+      visible: auth.loggedIn,
     },
   ];
 };

--- a/src/home/pages/home-profile.component.vue
+++ b/src/home/pages/home-profile.component.vue
@@ -2,22 +2,23 @@
 import Avatar from "primevue/avatar";
 import { PrimeIcons } from "primevue/api";
 import { AuthenticationService } from "@/accounts/services/authentication.service";
-import { onBeforeMount, ref, watchEffect } from "vue";
+import { onBeforeMount, watchEffect } from "vue";
+import { $ref } from "vue/macros";
 import { useRouter } from "vue-router";
 
-const auth = ref(AuthenticationService.instance);
-const user = ref(auth.value.getCurrentUser());
+const auth = $ref(AuthenticationService.instance);
+let user = $ref(auth.getCurrentUser());
 
 const router = useRouter();
 
 onBeforeMount(() => {
-  if (!auth.value.loggedIn) {
+  if (!auth.loggedIn) {
     router.push("/account/signin");
   }
 });
 
 watchEffect(() => {
-  user.value = auth.value.getCurrentUser();
+  user = auth.getCurrentUser();
 });
 </script>
 <template>

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,7 +5,11 @@ import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [vue()],
+  plugins: [
+    vue({
+      reactivityTransform: true,
+    }),
+  ],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

This pull request enables the experimental [Reactivity Transform](https://vuejs.org/guide/extras/reactivity-transform.html) build system that will allow us to access `ref` values without using `.value`.

### Usage

Import `ref` as follows:

```vue
<script setup>
// Notice that its importing from `vue/macros`, not `vue`
import { $ref } from "vue/macros";

// Initialize same as with `ref`, but include use `$ref`.
let count = $ref(0);

// You no longer need to use `.value` whenever you want to access a `ref`
const update = () => count++;
</script>

<template>
  <!-- It was never needed when using it inside templates -->
  <span @click="update">{{ count }}</span>
</template>
```

References to refs will be compiled back to using `.value` during build-time.

### Why is it needed

Developer experience.

