### PR TITLE
revert: "build: Reactivity Transform"

### DIFF
--- a/src/accounts/pages/sign-in.component.vue
+++ b/src/accounts/pages/sign-in.component.vue
@@ -1,17 +1,17 @@
 <script setup>
 import InputText from "primevue/inputtext";
-import { $ref } from "vue/macros";
+import { ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
 import { AuthenticationService } from "../services/authentication.service";
 
-const email = $ref("");
-const password = $ref("");
+const email = ref("");
+const password = ref("");
 
 const router = useRouter();
-const auth = $ref(AuthenticationService.instance);
+const auth = ref(AuthenticationService.instance);
 
 const handleLogin = () => {
-  auth.login();
+  auth.value.login();
   router.push("/");
 };
 </script>

--- a/src/accounts/pages/sign-up.component.vue
+++ b/src/accounts/pages/sign-up.component.vue
@@ -3,22 +3,22 @@ import InputMask from "primevue/inputmask";
 import InputText from "primevue/inputtext";
 import ToggleButton from "primevue/togglebutton";
 import { PrimeIcons } from "primevue/api";
-import { $ref } from "vue/macros";
+import { ref } from "vue";
 import { AuthenticationService } from "../services/authentication.service";
 import { useRouter, RouterLink } from "vue-router";
 
-const checked = $ref(false);
-const fullname = $ref("");
-const username = $ref("");
-const email = $ref("");
-const password = $ref("");
-const phone = $ref("");
+const checked = ref(false);
+const fullname = ref("");
+const username = ref("");
+const email = ref("");
+const password = ref("");
+const phone = ref("");
 
-const auth = $ref(AuthenticationService.instance);
+const auth = ref(AuthenticationService.instance);
 const router = useRouter();
 
 const handleRegister = () => {
-  auth.login();
+  auth.value.login();
   router.push("/");
 };
 </script>

--- a/src/core/components/base-footer.vue
+++ b/src/core/components/base-footer.vue
@@ -1,6 +1,6 @@
 <script setup>
 import Dropdown from "primevue/dropdown";
-import { $ref } from "vue/macros";
+import { ref } from "vue";
 
 const navigation = [
   {
@@ -30,7 +30,7 @@ const languages = [
   { label: "English", code: "en_US" },
   { label: "Spanish", code: "es_PE" },
 ];
-const selectedLang = $ref(languages[0]);
+const selectedLang = ref(languages[0]);
 </script>
 
 <template>

--- a/src/core/components/base-header.vue
+++ b/src/core/components/base-header.vue
@@ -3,8 +3,7 @@ import Menu from "primevue/menu";
 import Avatar from "primevue/avatar";
 import { PrimeIcons } from "primevue/api";
 import { useMq } from "vue3-mq";
-import { onMounted, watchEffect } from "vue";
-import { $ref } from "vue/macros";
+import { onMounted, ref, watchEffect } from "vue";
 import { RouterLink, useRouter } from "vue-router";
 import { AuthenticationService } from "@/accounts/services/authentication.service";
 
@@ -12,11 +11,11 @@ const mq = useMq();
 
 const router = useRouter();
 
-const auth = $ref(AuthenticationService.instance);
-let user = $ref(auth.getCurrentUser());
+const auth = ref(AuthenticationService.instance);
+const user = ref(auth.value.getCurrentUser());
 
 watchEffect(() => {
-  user = auth.getCurrentUser();
+  user.value = auth.value.getCurrentUser();
 });
 
 const navigation = [
@@ -26,47 +25,47 @@ const navigation = [
   { label: "Notices", path: "/notifications", icon: PrimeIcons.BELL },
 ];
 
-const search = $ref("");
+const search = ref("");
 
-/** @type {import("primevue/menu").default} */
-const menuRef = $ref();
+/** @type {import("vue").Ref<import("primevue/menu").default>} */
+const menuRef = ref();
 /** @param {MouseEvent} event */
 const toggleMenu = event => {
-  menuRef.toggle(event);
+  menuRef.value.toggle(event);
 };
 
 /** @type {import("vue").Ref<import("primevue/menuitem").MenuItem[]>} */
-let accountMenu = $ref([]);
+const accountMenu = ref([]);
 const updateMenu = () => {
-  accountMenu = [
+  accountMenu.value = [
     {
       label: "Sign In",
       to: "/account/signin",
       icon: PrimeIcons.SIGN_IN,
-      visible: !auth.loggedIn,
+      visible: !auth.value.loggedIn,
     },
     {
       label: "Sign Up",
       to: "/account/signup",
       icon: PrimeIcons.USER_PLUS,
-      visible: !auth.loggedIn,
+      visible: !auth.value.loggedIn,
     },
     ...navigation.map(item => ({
       label: item.label,
       icon: item.icon,
-      visible: mq.mdMinus && auth.loggedIn,
+      visible: mq.mdMinus && auth.value.loggedIn,
     })),
-    { separator: true, visible: mq.mdMinus && auth.loggedIn },
-    { label: "Profile", icon: PrimeIcons.USER, visible: auth.loggedIn },
-    { label: "Options", icon: PrimeIcons.COG, visible: auth.loggedIn },
+    { separator: true, visible: mq.mdMinus && auth.value.loggedIn },
+    { label: "Profile", icon: PrimeIcons.USER, visible: auth.value.loggedIn },
+    { label: "Options", icon: PrimeIcons.COG, visible: auth.value.loggedIn },
     {
       label: "Sign Out",
       command: () => {
-        auth.logout();
+        auth.value.logout();
         router.push("/account/signin");
       },
       icon: PrimeIcons.POWER_OFF,
-      visible: auth.loggedIn,
+      visible: auth.value.loggedIn,
     },
   ];
 };

--- a/src/home/pages/home-profile.component.vue
+++ b/src/home/pages/home-profile.component.vue
@@ -2,23 +2,22 @@
 import Avatar from "primevue/avatar";
 import { PrimeIcons } from "primevue/api";
 import { AuthenticationService } from "@/accounts/services/authentication.service";
-import { onBeforeMount, watchEffect } from "vue";
-import { $ref } from "vue/macros";
+import { onBeforeMount, ref, watchEffect } from "vue";
 import { useRouter } from "vue-router";
 
-const auth = $ref(AuthenticationService.instance);
-let user = $ref(auth.getCurrentUser());
+const auth = ref(AuthenticationService.instance);
+const user = ref(auth.value.getCurrentUser());
 
 const router = useRouter();
 
 onBeforeMount(() => {
-  if (!auth.loggedIn) {
+  if (!auth.value.loggedIn) {
     router.push("/account/signin");
   }
 });
 
 watchEffect(() => {
-  user = auth.getCurrentUser();
+  user.value = auth.value.getCurrentUser();
 });
 </script>
 <template>

--- a/vite.config.js
+++ b/vite.config.js
@@ -5,11 +5,7 @@ import vue from "@vitejs/plugin-vue";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [
-    vue({
-      reactivityTransform: true,
-    }),
-  ],
+  plugins: [vue()],
   resolve: {
     alias: {
       "@": fileURLToPath(new URL("./src", import.meta.url)),


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

Reverts #28 due to issues with the experimental Reactivity Transform.

### Usage

Just continue using `.value` to unwrap `refs`.

### Why is it needed

This was causing a lot of build and runtime issues and bugs.

### Related issue(s)/PR(s)

Initially added in #28.

### Additional context

Since this is experimental APIs, they don't work as expected right now
