### PR TITLE
refactor(service): Service Injection

### DIFF
--- a/src/accounts/pages/sign-in.component.vue
+++ b/src/accounts/pages/sign-in.component.vue
@@ -2,9 +2,9 @@
 import InputText from "primevue/inputtext";
 import { ref } from "vue";
 import { useRouter, RouterLink } from "vue-router";
-import { GlobalAuthService } from "../services/auth.service";
+import { useAuth } from "../services/auth.service";
 
-const auth = GlobalAuthService;
+const auth = useAuth();
 const router = useRouter();
 
 const user = ref({

--- a/src/accounts/pages/sign-up.component.vue
+++ b/src/accounts/pages/sign-up.component.vue
@@ -3,10 +3,10 @@ import InputText from "primevue/inputtext";
 import ToggleButton from "primevue/togglebutton";
 import { PrimeIcons } from "primevue/api";
 import { ref } from "vue";
-import { GlobalAuthService } from "../services/auth.service";
+import { useAuth } from "../services/auth.service";
 import { useRouter, RouterLink } from "vue-router";
 
-const auth = GlobalAuthService;
+const auth = useAuth();
 const router = useRouter();
 
 const user = ref({

--- a/src/accounts/services/auth.service.js
+++ b/src/accounts/services/auth.service.js
@@ -1,6 +1,7 @@
 import { BaseService } from "@/core/services/base.service";
 import { http } from "@/core/services/http-common";
-import { reactive } from "vue";
+import { AuthServiceKey } from "@/core/utils/keys";
+import { inject, reactive } from "vue";
 
 export class AuthService extends BaseService {
   state = reactive({ user: null });
@@ -56,4 +57,9 @@ export class AuthService extends BaseService {
   }
 }
 
-export const GlobalAuthService = new AuthService();
+/**
+ * @returns {AuthService}
+ */
+export const useAuth = () => {
+  return inject(AuthServiceKey, null);
+};

--- a/src/core/components/base-header.vue
+++ b/src/core/components/base-header.vue
@@ -5,13 +5,13 @@ import { PrimeIcons } from "primevue/api";
 import { useMq } from "vue3-mq";
 import { ref, watchEffect } from "vue";
 import { RouterLink, useRouter } from "vue-router";
-import { GlobalAuthService } from "@/accounts/services/auth.service";
+import { useAuth } from "@/accounts/services/auth.service";
 
 const mq = useMq();
 
 const router = useRouter();
 
-const auth = GlobalAuthService;
+const auth = useAuth();
 const user = ref(auth.user);
 
 watchEffect(() => {

--- a/src/core/services/base.service.js
+++ b/src/core/services/base.service.js
@@ -1,9 +1,6 @@
 import { http } from "@/core/services/http-common";
 
 export class BaseService {
-  /** @type {string} */
-  endpoint = "";
-
   /**
    * @param {string} path
    */

--- a/src/core/utils/keys.js
+++ b/src/core/utils/keys.js
@@ -1,0 +1,1 @@
+export const AuthServiceKey = Symbol("AuthService");

--- a/src/core/utils/keys.js
+++ b/src/core/utils/keys.js
@@ -1,1 +1,2 @@
 export const AuthServiceKey = Symbol("AuthService");
+export const JobsServiceKey = Symbol("JobsService");

--- a/src/home/pages/home-profile.component.vue
+++ b/src/home/pages/home-profile.component.vue
@@ -1,12 +1,12 @@
 <script setup>
 import Avatar from "primevue/avatar";
 import { PrimeIcons } from "primevue/api";
-import { GlobalAuthService } from "@/accounts/services/auth.service";
+import { useAuth } from "@/accounts/services/auth.service";
 import { onBeforeMount, ref, watchEffect } from "vue";
 import { useRouter } from "vue-router";
 import { toLocaleMonth } from "@/core/utils/months";
 
-const auth = GlobalAuthService;
+const auth = useAuth();
 const user = ref(auth.user);
 
 const router = useRouter();

--- a/src/jobs/pages/job-offers-display.component.vue
+++ b/src/jobs/pages/job-offers-display.component.vue
@@ -2,7 +2,7 @@
 import DataTable from "primevue/datatable";
 import Column from "primevue/column";
 import Button from "primevue/button";
-import { JobsService } from "../services/jobs.service";
+import { useJobs } from "../services/jobs.service";
 import { ref, onMounted } from "vue";
 import { PrimeIcons } from "primevue/api";
 import ConfirmDialog from "primevue/confirmdialog";
@@ -10,7 +10,7 @@ import Toast from "primevue/toast";
 import { useConfirm } from "primevue/useconfirm";
 import { useToast } from "primevue/usetoast";
 
-const service = new JobsService();
+const service = useJobs();
 const jobs = ref([]);
 
 const confirm = useConfirm();

--- a/src/jobs/services/jobs.service.js
+++ b/src/jobs/services/jobs.service.js
@@ -1,5 +1,7 @@
 import { BaseService } from "@/core/services/base.service";
 import { http } from "@/core/services/http-common";
+import { JobsServiceKey } from "@/core/utils/keys";
+import { inject } from "vue";
 
 export class JobsService extends BaseService {
   constructor() {
@@ -14,4 +16,9 @@ export class JobsService extends BaseService {
   }
 }
 
-export const GlobalJobsService = new JobsService();
+/**
+ * @returns {JobsService}
+ */
+export const useJobs = () => {
+  return inject(JobsServiceKey, null);
+};

--- a/src/main.js
+++ b/src/main.js
@@ -5,6 +5,8 @@ import PrimeVue from "primevue/config";
 import { Vue3Mq } from "vue3-mq";
 import ConfirmationService from "primevue/confirmationservice";
 import ToastService from "primevue/toastservice";
+import { AuthServiceKey } from "./core/utils/keys";
+import { AuthService } from "./accounts/services/auth.service";
 import "@/assets/base.css";
 
 const app = createApp(App);
@@ -14,5 +16,7 @@ app.use(PrimeVue);
 app.use(Vue3Mq, { preset: "tailwind" });
 app.use(ConfirmationService);
 app.use(ToastService);
+
+app.provide(AuthServiceKey, new AuthService());
 
 app.mount("#app");

--- a/src/main.js
+++ b/src/main.js
@@ -5,9 +5,10 @@ import PrimeVue from "primevue/config";
 import { Vue3Mq } from "vue3-mq";
 import ConfirmationService from "primevue/confirmationservice";
 import ToastService from "primevue/toastservice";
-import { AuthServiceKey } from "./core/utils/keys";
+import { AuthServiceKey, JobsServiceKey } from "./core/utils/keys";
 import { AuthService } from "./accounts/services/auth.service";
 import "@/assets/base.css";
+import { JobsService } from "./jobs/services/jobs.service";
 
 const app = createApp(App);
 
@@ -18,5 +19,6 @@ app.use(ConfirmationService);
 app.use(ToastService);
 
 app.provide(AuthServiceKey, new AuthService());
+app.provide(JobsServiceKey, new JobsService());
 
 app.mount("#app");


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

<!--

Before you start, please make sure your issue is understandable and reproducible.
To make your issue readable make sure you use valid Markdown syntax.

https://guides.github.com/features/mastering-markdown/

-->

### What does it do

This PR implements the [inject/provide model](https://vuejs.org/guide/components/provide-inject.html) for Vue.js for services.

### Usage

Any new services should create a new key inside `keys.js`, like this:

```js
// src/core/utils/keys.js
// ...more keys
// Format:
// const {YourServiceName}Key = Symbol("{YourServiceName}");
// Example:
const NewServiceKey = Symbol("NewService");
```

Then, import your key and service in `main.js` and provide your service on `main.js`:

```js
// ...more provide calls
app.provide(NewServiceKey, new NewService());
// ...more content
```

Also export a function returning the injection using the key you created:

```js
// at the end of your service file
// name the function appropriately
export const useService = () => {
  return inject(NewServiceKey, null);
}
```

Finally, use this function wherever you need this service.

### Why is it needed

Improve service usage.

### Related issue(s)/PR(s)

The original PR was #38, but it was incorrectly merged to the `main` branch. #39 reverted it and this is new against the `develop` branch.

#33 implemented the second refactor of services.
